### PR TITLE
Fix shoulda-matcher, setup factories, add ffaker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description of work
+<!-- Add a description of the work here, along with any story id/link or screenshots -->
+
+## Type of Change
+<!-- Put an x in the box that applies like [x] -->
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Chore (Minor requested change)
+
+## Checklist
+<!-- Put an x in the boxes as they are complete -->
+
+- [ ] I have added tests to prove my feature is functional
+- [ ] My code is sufficiently documented, include sample of how to use the component

--- a/Gemfile
+++ b/Gemfile
@@ -32,13 +32,14 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'factory_bot_rails'
+  gem 'ffaker'
   gem 'rspec-rails', '~> 4.0.1'
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '~> 3.2'
+  gem 'web-console', '>= 3.3.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
+    ffaker (2.17.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -227,6 +228,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   factory_bot_rails
+  ffaker
   jbuilder (~> 2.7)
   listen (~> 3.2)
   puma (~> 4.1)

--- a/spec/factories/trucks.rb
+++ b/spec/factories/trucks.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :truck do
+    sequence(:license_plate) { |n| "#{FFaker::Lorem.word}#{n}" }
+    capacity { rand(10_000..50_000) }
+    # model_type_id { }
+    color { FFaker::Vehicle.base_color }
+    service_date { Date.current }
+    active
+    # drivers_id { }
+
+    trait :active do
+      status { 'active' }
+    end
+
+    trait :inactive do
+      status { 'inactive' }
+    end
+
+    trait :inactive do
+      status { 'inactive' }
+    end
+  end
+end

--- a/spec/factories/trucks.rb
+++ b/spec/factories/trucks.rb
@@ -16,8 +16,8 @@ FactoryBot.define do
       status { 'inactive' }
     end
 
-    trait :inactive do
-      status { 'inactive' }
+    trait :servicing do
+      status { 'servicing' }
     end
   end
 end

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -4,7 +4,9 @@ describe Truck do
   describe 'validations' do
     subject { truck.valid? }
 
-    let(:truck) { Truck.new(license_plate: license_plate, capacity: capacity, status: status) }
+    let(:truck) do
+      build(:truck, :active, license_plate: license_plate, capacity: capacity, status: status)
+    end
     let(:license_plate) { '1234' }
     let(:capacity) { 100 }
     let(:status) { :active }
@@ -14,7 +16,7 @@ describe Truck do
 
       it { is_expected.to be_falsey }
     end
-    
+
     context 'capacity is not present' do
       let(:capacity) { nil }
 
@@ -28,10 +30,11 @@ describe Truck do
     end
 
     it { is_expected.to be_truthy }
-  end 
+  end
 
-  # describe 'validations with shoulda-matchers' do
-  #   it { is_expected.to validate_presence_of(:license_plate) }
-  #   it { is_expected.to validate_presence_of(:capacity) }
-  # end
+  describe 'validations with shoulda-matchers' do
+    it { is_expected.to validate_presence_of(:license_plate) }
+    it { is_expected.to validate_presence_of(:capacity) }
+    it { is_expected.to define_enum_for(:status).with_values(Truck.statuses.keys) }
+  end
 end

--- a/spec/models/truck_spec.rb
+++ b/spec/models/truck_spec.rb
@@ -5,7 +5,7 @@ describe Truck do
     subject { truck.valid? }
 
     let(:truck) do
-      build(:truck, :active, license_plate: license_plate, capacity: capacity, status: status)
+      build(:truck, license_plate: license_plate, capacity: capacity, status: status)
     end
     let(:license_plate) { '1234' }
     let(:capacity) { 100 }


### PR DESCRIPTION
## Description of work
<!-- Add a description of the work here, along with any story id/link or screenshots -->
model specs were not in a `model` directory which caused the infer spec type by location logic to fail.
setup a factory for trucks as an example.
use ffaker for better data.

## Type of Change
<!-- Put an x in the box that applies like [x] -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Chore (Minor requested change)

## Checklist
<!-- Put an x in the boxes as they are complete -->

- [x] I have added tests to prove my feature is functional
- [x] My code is sufficiently documented, include sample of how to use the component
